### PR TITLE
bump x/redis version to 0.24.0

### DIFF
--- a/src/stores/RedisStore.ts
+++ b/src/stores/RedisStore.ts
@@ -1,5 +1,5 @@
 import Store from './Store.ts'
-import { Redis, Bulk } from 'https://deno.land/x/redis@v0.22.2/mod.ts'
+import { Redis } from 'https://deno.land/x/redis@v0.24.0/mod.ts'
 
 export default class RedisStore implements Store {
   keyPrefix : string


### PR DESCRIPTION
The latest deno x/redis version is 0.24.0. The type `Redis` from 0.24.0 is no longer compatible with that in `0.22.2`, you will get a type error when using oak_sessions together with the latest x/redis.

So I made a commit to bump the version. There wasn't too much to change actually.