### PR TITLE
chore: bump oak to v10.1.0, redis to v0.25.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ import { Application, Router } from "https://deno.land/x/oak/mod.ts";
 import { Session, RedisStore } from "https://deno.land/x/oak_sessions/mod.ts";
 
 // import the Redis library
-import { connect } from 'https://deno.land/x/redis@v0.22.2/mod.ts'
+import { connect } from 'https://deno.land/x/redis@v0.25.0/mod.ts'
 
 const app = new Application();
 

--- a/src/Session.ts
+++ b/src/Session.ts
@@ -1,10 +1,10 @@
 import { nanoid } from 'https://deno.land/x/nanoid@v3.0.0/async.ts'
 import MemoryStore from './stores/MemoryStore.ts'
 import CookieStore from './stores/CookieStore.ts'
-import { Context } from 'https://deno.land/x/oak@v10.0.0/context.ts'
+import { Context } from 'https://deno.land/x/oak@v10.1.0/context.ts'
 import Store from './stores/Store.ts'
 import { DateTime } from 'https://jspm.dev/luxon@2.0.2'
-import { CookiesGetOptions, CookiesSetDeleteOptions } from 'https://deno.land/x/oak@v10.0.0/cookies.ts'
+import type { CookiesGetOptions, CookiesSetDeleteOptions } from 'https://deno.land/x/oak@v10.1.0/cookies.ts'
 
 interface SessionOptions {
   expireAfterSeconds?: number

--- a/src/stores/CookieStore.ts
+++ b/src/stores/CookieStore.ts
@@ -1,6 +1,6 @@
 import CryptoJS from 'https://cdn.skypack.dev/crypto-js@4.1.1'
 import Store from './Store.ts'
-import { Context } from 'https://deno.land/x/oak@v10.0.0/context.ts'
+import type { Context } from 'https://deno.land/x/oak@v10.1.0/context.ts'
 import { SessionData } from '../Session.ts'
 
 export default class CookieStore implements Store{

--- a/src/stores/MemoryStore.ts
+++ b/src/stores/MemoryStore.ts
@@ -1,5 +1,4 @@
 import Store from './Store.ts'
-import { Redis } from 'https://deno.land/x/redis@v0.22.2/mod.ts'
 import { SessionData } from '../Session.ts'
 
 export default class MemoryStore implements Store {

--- a/src/stores/RedisStore.ts
+++ b/src/stores/RedisStore.ts
@@ -1,5 +1,5 @@
 import Store from './Store.ts'
-import { Redis } from 'https://deno.land/x/redis@v0.24.0/mod.ts'
+import type { Redis } from 'https://deno.land/x/redis@v0.25.0/mod.ts'
 import { SessionData } from '../Session.ts'
 
 export default class RedisStore implements Store {

--- a/src/stores/Store.ts
+++ b/src/stores/Store.ts
@@ -1,4 +1,4 @@
-import { Context } from 'https://deno.land/x/oak@v10.0.0/context.ts'
+import type { Context } from 'https://deno.land/x/oak@v10.1.0/context.ts'
 import { SessionData } from '../Session.ts'
 
 export default interface Store {

--- a/test/server.ts
+++ b/test/server.ts
@@ -1,6 +1,6 @@
-import { Application, Router, Context } from "https://deno.land/x/oak@v10.0.0/mod.ts"
+import { Application, Router, Context } from "https://deno.land/x/oak@v10.1.0/mod.ts"
 import { Session, RedisStore, SqliteStore, WebdisStore, MemoryStore, CookieStore } from '../mod.ts'
-import { connect as connectRedis } from 'https://deno.land/x/redis@v0.22.2/mod.ts'
+import { connect as connectRedis } from 'https://deno.land/x/redis@v0.25.0/mod.ts'
 import { DB as sqliteDB } from 'https://deno.land/x/sqlite@v2.4.0/mod.ts'
 
 const app = new Application()


### PR DESCRIPTION
Having problem using it with oak v10.1.0. Typescript complains about an incompatible type.

I've upgraded oak and redis to latest version.