### PR TITLE
Redesign `Session` to represent one request-response session.

### DIFF
--- a/src/stores/CookieStore.ts
+++ b/src/stores/CookieStore.ts
@@ -1,91 +1,67 @@
 import CryptoJS from 'https://cdn.skypack.dev/crypto-js@4.1.1'
-import Store from './Store.ts'
 import type { Context, CookiesGetOptions, CookiesSetDeleteOptions } from '../../deps.ts'
-import { SessionData } from '../Session.ts'
+import type { SessionData } from '../Session.ts'
 
 interface CookieStoreOptions {
   cookieGetOptions?: CookiesGetOptions;
   cookieSetDeleteOptions?: CookiesSetDeleteOptions;
 }
 
-export default class CookieStore implements Store{
-  data: SessionData | null
-  
+export default class CookieStore {
   encryptionKey: string | null
-  context : Context | null
 
   cookieGetOptions: CookiesGetOptions;
   cookieSetDeleteOptions: CookiesSetDeleteOptions;
 
   constructor(encryptionKey : string | null = null, options? : CookieStoreOptions) {
-    this.data = null
     this.encryptionKey = encryptionKey
-    this.context = null
 
     this.cookieGetOptions = options?.cookieGetOptions ?? {}
     this.cookieSetDeleteOptions = options?.cookieSetDeleteOptions ?? {}
   }
 
-  async insertSessionMiddlewareContext(ctx : Context) {
-    this.context = ctx
+  async getSessionByCtx(ctx : Context) : Promise<SessionData | null> {
+    const sessionDataString : string | undefined = await ctx.cookies.get('session_data', this.cookieGetOptions)
 
-    const sessionDataString : string | undefined = await this.context.cookies.get('session_data', this.cookieGetOptions)
+    if (!sessionDataString) return null;
 
-    if (await this.sessionExists()) {
-      if (this.encryptionKey) {
-        const rawString = sessionDataString
-        let bytes = CryptoJS.AES.decrypt(rawString, this.encryptionKey)
-        let decryptedCookie : string = ''
+    if (this.encryptionKey) {
+      const rawString = sessionDataString
+      const bytes = CryptoJS.AES.decrypt(rawString, this.encryptionKey)
 
-        try {
-          decryptedCookie = bytes.toString(CryptoJS.enc.Utf8)
-        } catch (e) {
-          this.data = null
-        }
+      try {
+        const decryptedCookie = bytes.toString(CryptoJS.enc.Utf8)
+        return JSON.parse(decryptedCookie)
+      } catch (_e) {
+        return null
+      }
         
-        if (decryptedCookie) {
-          try {
-            this.data = JSON.parse(decryptedCookie)
-          } catch (e) {
-            this.data = null
-          }
-        }
-      } else {
-        try {
-          this.data = typeof sessionDataString == 'string' ? JSON.parse(sessionDataString) as SessionData : null
-        } catch (e) {
-          this.data = null
-        }
+    } else {
+      try {
+        return typeof sessionDataString === 'string' ? JSON.parse(sessionDataString) : null
+      } catch (_e) {
+        return null
       }
     }
   }
 
-  async sessionExists() {
-    return await this.context?.cookies.get('session_data', this.cookieGetOptions) ? true : false
+  async createSession(ctx : Context, initialData : SessionData) {
+    let dataString = JSON.stringify(initialData)
+
+    if (this.encryptionKey)
+      dataString = CryptoJS.AES.encrypt(dataString, this.encryptionKey).toString()
+    await ctx.cookies.set('session_data', dataString, this.cookieSetDeleteOptions)
   }
 
-  async getSessionById() {
-    return await this.context?.cookies.get('session_data', this.cookieGetOptions) ? this.data : null
+  deleteSession(ctx : Context) {
+    ctx.cookies.delete('session_data', this.cookieSetDeleteOptions)
   }
 
-  createSession(id : string, initialData : SessionData) {
-    this.data = initialData
-  }
+  async persistSessionData(ctx : Context, data : SessionData) {
+    let dataString = JSON.stringify(data)
 
-  async deleteSession(ctx : Context) {
-    await this.context?.cookies.delete('session_data', this.cookieSetDeleteOptions)
-  }
-
-  persistSessionData(id : string, sessionData : SessionData) {
-    this.data = sessionData
-  }
-
-  async afterMiddlewareHook() {
-    if (this.encryptionKey) {
-      let cipherText = CryptoJS.AES.encrypt(JSON.stringify(this.data), this.encryptionKey).toString()
-      await this.context?.cookies.set('session_data', cipherText, this.cookieSetDeleteOptions)
-    } else {
-      await this.context?.cookies.set('session_data', JSON.stringify(this.data), this.cookieSetDeleteOptions)
-    }
+    if (this.encryptionKey)
+      dataString = CryptoJS.AES.encrypt(dataString, this.encryptionKey).toString()
+    await ctx.cookies.set('session_data', dataString, this.cookieSetDeleteOptions)
   }
 }

--- a/src/stores/Store.ts
+++ b/src/stores/Store.ts
@@ -1,5 +1,5 @@
 import type { Context } from '../../deps.ts'
-import { SessionData } from '../Session.ts'
+import type { SessionData } from '../Session.ts'
 
 export default interface Store {
   sessionExists(sessionId?: string) : Promise<boolean> | boolean
@@ -7,6 +7,4 @@ export default interface Store {
   createSession(sessionId: string, initialData: SessionData) : Promise<void> | void
   persistSessionData(sessionId: string, sessionData: SessionData) : Promise<void> | void
   deleteSession(sessionIdOrContext: string | Context) : Promise<void> | void
-  insertSessionMiddlewareContext?(context : any) : Promise<void> | void
-  afterMiddlewareHook?() : Promise<void> | void
 }

--- a/test/makeStore.ts
+++ b/test/makeStore.ts
@@ -4,10 +4,10 @@ import { DB as sqliteDB } from "https://deno.land/x/sqlite@v3.4.0/mod.ts"
 import { MongoClient } from "https://deno.land/x/mongo@v0.29.4/mod.ts";
 import postgres from "https://deno.land/x/postgresjs@v3.1.0/mod.js"
 
-export async function makeStore(): Promise<Store> {
+export async function makeStore(): Promise<Store | CookieStore> {
   switch(Deno.env.get('STORE')) {
     case 'cookie':
-      return new CookieStore('a-secret-key')
+      return new CookieStore('qwqwq')
     case 'sqlite':
       const sqlite = new sqliteDB('./database.db')
       return new SqliteStore(sqlite)

--- a/test/server.ts
+++ b/test/server.ts
@@ -15,23 +15,24 @@ const router = new Router<AppState>();
 
 // Instantiate session
 const store = await makeStore()
-const session = new Session(store)
+Session.store = store;
+// const session = new Session(store)
 
 // Apply sessions to your Oak application. You can also apply the middleware to specific routes instead of the whole app.
-app.use(session.initMiddleware())
+app.use(Session.initMiddleware())
 
 router.post('/login', async (ctx) => {
     const form = await ctx.request.body({type: 'form'}).value
     if(form.get('password') === 'correct') {
         // Set persistent data in the session
-        await ctx.state.session.set('email', form.get('email'))
-        await ctx.state.session.set('failed-login-attempts', null)
+        ctx.state.session.set('email', form.get('email'))
+        ctx.state.session.set('failed-login-attempts', null)
         // Set flash data in the session. This will be removed the first time it's accessed with get
-        await ctx.state.session.flash('message', 'Login successful')
+        ctx.state.session.flash('message', 'Login successful')
     } else {
         const failedLoginAttempts = (await ctx.state.session.get('failed-login-attempts') || 0) as number
-        await ctx.state.session.set('failed-login-attempts', failedLoginAttempts+1)
-        await ctx.state.session.flash('error', 'Incorrect username or password')
+        ctx.state.session.set('failed-login-attempts', failedLoginAttempts+1)
+        ctx.state.session.flash('error', 'Incorrect username or password')
     }
     ctx.response.redirect('/')
 })


### PR DESCRIPTION
`Session` and `CookieStore` are redesigned as discussed in issue #19 

Other stores are not changed. Session interfaces changes a bit.