### PR TITLE
Upgrade to latest version of Redis

### DIFF
--- a/src/stores/RedisStore.ts
+++ b/src/stores/RedisStore.ts
@@ -1,5 +1,5 @@
 import Store from './Store.ts'
-import type { Redis } from 'https://deno.land/x/redis@v0.25.0/mod.ts'
+import type { Redis } from 'https://deno.land/x/redis@v0.27.0/mod.ts'
 import { SessionData } from '../Session.ts'
 
 export default class RedisStore implements Store {


### PR DESCRIPTION
I am attempting to use v0.27.0 of redis, since 0.25.0 doesn't let you pass username and password when connecting, but doing so leads to a type error when you attempt to pass the `Redis` instance to the `RedisStore` constructor:

```
Argument of type 'import("https://deno.land/x/redis@v0.27.0/redis").Redis' is not assignable to parameter of type 'import("https://deno.land/x/redis@v0.25.0/redis").Redis'.
  The types returned by 'sendCommand(...)' are incompatible between these types.
    Type 'Promise<import("https://deno.land/x/redis@v0.27.0/protocol/types").RedisReply>' is not assignable to type 'Promise<import("https://deno.land/x/redis@v0.25.0/protocol/types").RedisReply>'.
      Type 'import("https://deno.land/x/redis@v0.27.0/protocol/types").RedisReply' is not assignable to type 'import("https://deno.land/x/redis@v0.25.0/protocol/types").RedisReply'.
        Property 'type' is missing in type 'RedisReply' but required in type 'BulkReply'.
```