### PR TITLE
Make cookie names configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,9 @@ app.addEventListener('error', (evt) => {
 
 const router = new Router<AppState>();
 
-// Apply sessions to your Oak application. You can also apply the middleware to specific routes instead of the whole app.
+// Apply sessions to your Oak application.
+// You can also apply the middleware to specific routes instead of the whole app.
+// Without params, default MemoryStore is used. See the Storage chapter below for more info.
 app.use(Session.initMiddleware())
 
 router.post('/login', async (ctx) => {
@@ -106,6 +108,7 @@ import { Application, Router } from "https://deno.land/x/oak/mod.ts";
 import { Session, CookieStore } from "https://deno.land/x/oak_sessions/mod.ts";
 
 const app = new Application();
+// cookie name for the store is configurable, default is: {sessionDataCookieName: 'session_data'}
 const store = new CookieStore('very-secret-key')
 
 // Attach sessions to middleware

--- a/src/Session.ts
+++ b/src/Session.ts
@@ -5,10 +5,12 @@ import type { Context, Middleware } from '../deps.ts'
 import type Store from './stores/Store.ts'
 import type { CookiesGetOptions, CookiesSetDeleteOptions } from '../deps.ts'
 
+
 interface SessionOptions {
   expireAfterSeconds?: number | null
   cookieGetOptions?: CookiesGetOptions
   cookieSetOptions?: CookiesSetDeleteOptions
+  sessionCookieName?: string
 }
 
 export interface SessionData {
@@ -38,12 +40,13 @@ export default class Session {
   static initMiddleware(store: Store | CookieStore = new MemoryStore(), {
     expireAfterSeconds = null,
     cookieGetOptions = {},
-    cookieSetOptions = {}
+    cookieSetOptions = {},
+    sessionCookieName = 'session'
   }: SessionOptions = {}) {
-  
+
     const initMiddleware: Middleware = async (ctx, next) => {
       // get sessionId from cookie
-      const sid = await ctx.cookies.get('session', cookieGetOptions)
+      const sid = await ctx.cookies.get(sessionCookieName, cookieGetOptions)
       let session: Session;
 
       if (sid) {
@@ -73,7 +76,7 @@ export default class Session {
 
       // update _access time
       session.set('_accessed', new Date().toISOString())
-      await ctx.cookies.set('session', session.sid, cookieSetOptions)
+      await ctx.cookies.set(sessionCookieName, session.sid, cookieSetOptions)
 
 
       await next()

--- a/src/stores/CookieStore.ts
+++ b/src/stores/CookieStore.ts
@@ -5,6 +5,7 @@ import type { SessionData } from '../Session.ts'
 interface CookieStoreOptions {
   cookieGetOptions?: CookiesGetOptions;
   cookieSetDeleteOptions?: CookiesSetDeleteOptions;
+  sessionDataCookieName?: string
 }
 
 export default class CookieStore {
@@ -12,16 +13,18 @@ export default class CookieStore {
 
   cookieGetOptions: CookiesGetOptions;
   cookieSetDeleteOptions: CookiesSetDeleteOptions;
+  sessionDataCookieName: string;
 
   constructor(encryptionKey : string, options? : CookieStoreOptions) {
     this.encryptionKey = encryptionKey
 
     this.cookieGetOptions = options?.cookieGetOptions ?? {}
     this.cookieSetDeleteOptions = options?.cookieSetDeleteOptions ?? {}
+    this.sessionDataCookieName = options?.sessionDataCookieName ?? 'session_data'
   }
 
   async getSessionByCtx(ctx : Context) : Promise<SessionData | null> {
-    const sessionDataString : string | undefined = await ctx.cookies.get('session_data', this.cookieGetOptions)
+    const sessionDataString : string | undefined = await ctx.cookies.get(this.sessionDataCookieName, this.cookieGetOptions)
 
     if (!sessionDataString) return null;
 
@@ -38,17 +41,17 @@ export default class CookieStore {
     const dataString = JSON.stringify(initialData)
 
     const encryptedCookie = await encryptCryptoJSAES(dataString, this.encryptionKey)
-    await ctx.cookies.set('session_data', encryptedCookie, this.cookieSetDeleteOptions)
+    await ctx.cookies.set(this.sessionDataCookieName, encryptedCookie, this.cookieSetDeleteOptions)
   }
 
   deleteSession(ctx : Context) {
-    ctx.cookies.delete('session_data', this.cookieSetDeleteOptions)
+    ctx.cookies.delete(this.sessionDataCookieName, this.cookieSetDeleteOptions)
   }
 
   async persistSessionData(ctx : Context, data : SessionData) {
     const dataString = JSON.stringify(data)
 
     const encryptedCookie = await encryptCryptoJSAES(dataString, this.encryptionKey)
-    await ctx.cookies.set('session_data', encryptedCookie, this.cookieSetDeleteOptions)
+    await ctx.cookies.set(this.sessionDataCookieName, encryptedCookie, this.cookieSetDeleteOptions)
   }
 }


### PR DESCRIPTION
Cookie names were hardcoded to pretty generic names `'session'` and `'session_data'`, respectively. They might potentially clash with other similar named cookies, especially when developing locally.

Added oak_ prefix to the default ones. Can theoretically be considered breaking change, as if user has active session, and the application below restarts with middleware upgraded to this change, middleware would consider user not having a session and thus requiring a new session init. With semi-short sessions it doesn't matter, but ofc there might be use case where it is expected for the session cookie to be there for very long time. 

Any thoughts come up about this cookie renaming?

